### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -318,15 +318,23 @@ if (basePath) {
 }
 
 // Route catch-all pour SPA
+// Define rate limiter for static file routes
+const staticFileLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 30, // limit each IP to 30 requests per minute
+  standardHeaders: true, // Return rate limit info in the RateLimit-* headers
+  legacyHeaders: false, // Disable the X-RateLimit-* headers
+});
+
 if (basePath) {
-  app.get(`${basePath}/*`, (req, res) => {
+  app.get(`${basePath}/*`, staticFileLimiter, (req, res) => {
     res.sendFile(join(__dirname, 'dist', 'index.html'));
   });
-  app.get(`${basePath}`, (req, res) => {
+  app.get(`${basePath}`, staticFileLimiter, (req, res) => {
     res.sendFile(join(__dirname, 'dist', 'index.html'));
   });
 } else {
-  app.get('*', (req, res) => {
+  app.get('*', staticFileLimiter, (req, res) => {
     res.sendFile(join(__dirname, 'dist', 'index.html'));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Liberchat/liberchatserver_ynh/security/code-scanning/3](https://github.com/Liberchat/liberchatserver_ynh/security/code-scanning/3)

To fix this problem, we should apply rate limiting middleware to the routes serving static files—in this case, the catch-all SPA routes (lines 322–331) that use `res.sendFile`. The best solution is to use the already-installed `express-rate-limit` library (imported as `rateLimit` on line 6). We can define a limiter instance with appropriate configuration and apply it specifically to these routes, ensuring that file system accesses are protected against abuse, while not impacting other routes that might require a different rate limit configuration.

The fix involves:
- Defining a `rateLimit` instance for static file access.
- Applying it as middleware on the SPA catch-all routes (`app.get('${basePath}/*'...)`, `app.get('${basePath}',...)`, `app.get('*',...)`).
- No additional dependencies are required, as `express-rate-limit` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
