### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   updater:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Fetch the source code
         uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/Liberchat/liberchatserver_ynh/security/code-scanning/8](https://github.com/Liberchat/liberchatserver_ynh/security/code-scanning/8)

To fix the problem, add a `permissions` block to the workflow. Since only the `updater` job exists, add the `permissions` block directly within that job. The job requires read access to the repository contents (for checking out code) and write access to pull requests (to create/update pull requests). Thus, set `contents: read` and `pull-requests: write` on the `updater` job. Edit `.github/workflows/updater.yml`, and insert the following below `runs-on: ubuntu-latest` (line 8):  
```yaml
permissions:
  contents: read
  pull-requests: write
```
No additional dependencies, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
